### PR TITLE
Add taxonomies

### DIFF
--- a/lib/solidus_graphql/all.rb
+++ b/lib/solidus_graphql/all.rb
@@ -2,6 +2,10 @@ require_relative "models/null_store"
 require_relative "helpers/pricing"
 
 # TODO: multiple files
+require_relative "types/taxonomy_type"
+require_relative "fields/taxonomies_field"
+require_relative "resolvers/taxonomy_resolver"
+
 require_relative "types/taxon_type"
 require_relative "fields/taxons_field"
 require_relative "resolvers/taxon_resolver"

--- a/lib/solidus_graphql/fields/taxonomies_field.rb
+++ b/lib/solidus_graphql/fields/taxonomies_field.rb
@@ -1,0 +1,14 @@
+module Solidus
+  module GraphQL
+    TaxonomiesField = ::GraphQL::Field.define do
+      name "taxonomies"
+      description "Taxonomies list"
+
+      argument :ids, types[types.ID]
+
+      type types[TaxonomyType]
+
+      resolve TaxonomyResolver::All
+    end
+  end
+end

--- a/lib/solidus_graphql/query.rb
+++ b/lib/solidus_graphql/query.rb
@@ -4,8 +4,9 @@ module Solidus
       name "Query"
       description "The query root of the schema"
 
-      field :products, ProductsField
-      field :taxons,   TaxonsField
+      field :products,   ProductsField
+      field :taxons,     TaxonsField
+      field :taxonomies, TaxonomiesField
     end
   end
 end

--- a/lib/solidus_graphql/resolvers/taxon_resolver.rb
+++ b/lib/solidus_graphql/resolvers/taxon_resolver.rb
@@ -6,6 +6,13 @@ module Solidus
           Spree::Taxon.all
         end
       end
+
+      class ByTaxonomy
+        def self.call(taxonomy, args, ctx)
+          # TODO: query(args)
+          taxonomy.taxons
+        end
+      end
     end
   end
 end

--- a/lib/solidus_graphql/resolvers/taxonomy_resolver.rb
+++ b/lib/solidus_graphql/resolvers/taxonomy_resolver.rb
@@ -1,0 +1,12 @@
+module Solidus
+  module GraphQL
+    class TaxonomyResolver
+      class All
+        def self.call(obj, args, ctx)
+          # TODO: query(args)
+          Spree::Taxonomy.all
+        end
+      end
+    end
+  end
+end

--- a/lib/solidus_graphql/types/taxonomy_type.rb
+++ b/lib/solidus_graphql/types/taxonomy_type.rb
@@ -12,6 +12,10 @@ module Solidus
           taxonomy.root
         end
       end
+
+      connection :taxons, TaxonType.connection_type do
+        resolve TaxonResolver::ByTaxonomy
+      end
     end
   end
 end

--- a/lib/solidus_graphql/types/taxonomy_type.rb
+++ b/lib/solidus_graphql/types/taxonomy_type.rb
@@ -6,6 +6,12 @@ module Solidus
       field :id,          types.ID
       field :name,        types.String
       field :position,    types.Int
+
+      field :root_taxon, TaxonType do
+        resolve ->(taxonomy, args, ctx) do
+          taxonomy.root
+        end
+      end
     end
   end
 end

--- a/lib/solidus_graphql/types/taxonomy_type.rb
+++ b/lib/solidus_graphql/types/taxonomy_type.rb
@@ -1,0 +1,11 @@
+module Solidus
+  module GraphQL
+    TaxonomyType = ::GraphQL::ObjectType.define do
+      name "Taxonomy"
+
+      field :id,          types.ID
+      field :name,        types.String
+      field :position,    types.Int
+    end
+  end
+end

--- a/spec/graphql/taxonomy_spec.rb
+++ b/spec/graphql/taxonomy_spec.rb
@@ -1,0 +1,21 @@
+require "spec_helper"
+
+describe "graphql taxonomy" do
+  let!(:taxonomy) { create_list(:taxonomy, 4) }
+
+  it "returns available taxonomies" do
+    available_taxonomies = <<-GRAPHQL
+    {
+      taxonomies {
+        name
+      }
+    }
+    GRAPHQL
+
+    response     = Solidus::GraphQL::Schema.execute(available_taxonomies)
+    taxonomies   = response.dig("data", "taxonomies")
+
+    expect(response["errors"]).to be_nil
+    expect(taxonomies.count).to eq(4)
+  end
+end


### PR DESCRIPTION
This is a simple PR that add taxonomies field with the basic informations.
@mihado after working on the code I've some doubt: 

How do you easy try the graph without a dummy app? 
For now I've installed the extension in an example solidus store but maybe a dummy app can help to hack on the Graph without setup another application, let me know if you like the idea and I'll do another PR for it.

I've also a question about GraphQl naming convention, around the internet I see that a lot off people use CamelCase for the field names, do you think we should move to it?